### PR TITLE
Update Android download link and highlight CTA

### DIFF
--- a/app-links.html
+++ b/app-links.html
@@ -50,7 +50,7 @@
             tap away.
           </p>
           <div class="hero-actions">
-            <a class="btn btn-primary" href="#android">Get it on Android</a>
+            <a class="btn btn-android" href="#android">Get it on Android</a>
             <a class="btn btn-secondary" href="#ios">iPhone waitlist</a>
           </div>
         </div>
@@ -101,8 +101,8 @@
               out regularly with fresh stories and new calming soundscapes.
             </p>
             <a
-              class="btn btn-primary"
-              href="https://play.google.com/store/apps/details?id=com.baboostories.app"
+              class="btn btn-android"
+              href="https://play.google.com/store/apps/details?id=baboo.stories"
               target="_blank"
               rel="noopener"
             >

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -182,6 +182,29 @@ main {
   background: rgba(255, 255, 255, 0.32);
 }
 
+.btn-android {
+  background: linear-gradient(135deg, var(--brand-secondary), #ffd27f);
+  color: var(--brand-dark);
+  border: 1px solid rgba(247, 183, 51, 0.4);
+  box-shadow: 0 18px 35px rgba(247, 183, 51, 0.35);
+  padding: 0.85rem 2rem;
+  font-size: 1.05rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+  gap: 0.6rem;
+}
+
+.btn-android:hover,
+.btn-android:focus {
+  transform: translateY(-3px);
+  box-shadow: 0 20px 40px rgba(247, 183, 51, 0.45);
+}
+
+.btn-android:focus-visible {
+  outline: 3px solid rgba(49, 198, 212, 0.7);
+  outline-offset: 2px;
+}
+
 .badge {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- update the Google Play download link to point at the baboo.stories listing
- introduce a dedicated Android button style to make the download CTA stand out

## Testing
- no automated tests were run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d1213b020883238cb5a1f84eec7486