### PR TITLE
Highlight home preview button

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -182,7 +182,8 @@ main {
   background: rgba(255, 255, 255, 0.32);
 }
 
-.btn-android {
+.btn-android,
+.btn-preview {
   background: linear-gradient(135deg, var(--brand-secondary), #ffd27f);
   color: var(--brand-dark);
   border: 1px solid rgba(247, 183, 51, 0.4);
@@ -195,12 +196,15 @@ main {
 }
 
 .btn-android:hover,
-.btn-android:focus {
+.btn-android:focus,
+.btn-preview:hover,
+.btn-preview:focus {
   transform: translateY(-3px);
   box-shadow: 0 20px 40px rgba(247, 183, 51, 0.45);
 }
 
-.btn-android:focus-visible {
+.btn-android:focus-visible,
+.btn-preview:focus-visible {
   outline: 3px solid rgba(49, 198, 212, 0.7);
   outline-offset: 2px;
 }

--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@
             <a class="btn btn-primary" href="early-bird-signup.html"
               >Join the Early Birds</a
             >
-            <a class="btn btn-secondary" href="app-links.html">Preview the App</a>
+            <a class="btn btn-preview" href="app-links.html">Preview the App</a>
           </div>
         </div>
         <div class="info-panel" aria-label="Highlights">


### PR DESCRIPTION
## Summary
- reuse the gradient call-to-action styling for the home page "Preview the App" button
- share the enhanced hover and focus treatment between Android and preview CTAs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d126d609c08323ba6833a6487db1f4