### PR TITLE
[codex] Fix canonical index links

### DIFF
--- a/TECHNICAL_CHECKLIST.md
+++ b/TECHNICAL_CHECKLIST.md
@@ -1,0 +1,92 @@
+# Baboo Stories Technical Checklist
+
+Use this checklist before publishing new pages or deploying website changes.
+
+## URL and indexing checklist
+
+- [ ] Use one preferred URL for every page.
+- [ ] Never add `index.html` to internal links.
+- [ ] Link to the homepage as `/`.
+- [ ] Link to directory-based articles with a trailing slash:
+  `/blog/article-name/`
+- [ ] Do not link to directory-based articles as:
+  `/blog/article-name/index.html`
+- [ ] Add one self-referencing canonical tag to every indexable page:
+
+  ```html
+  <link
+    rel="canonical"
+    href="https://baboostories.com/blog/article-name/"
+  />
+  ```
+
+- [ ] Make Open Graph URLs match the canonical URL.
+- [ ] Use only canonical URLs in `sitemap.xml`.
+- [ ] Do not include `/index.html` URLs in the sitemap.
+- [ ] Confirm important pages are not blocked by `robots.txt` or a `noindex`
+  directive.
+
+## New blog article checklist
+
+- [ ] Store a directory-based article at `blog/article-name/index.html`.
+- [ ] Use `https://baboostories.com/blog/article-name/` as its public URL.
+- [ ] Add the clean public URL to `sitemap.xml`.
+- [ ] Link to the clean URL from the homepage, blog listing, and related
+  articles.
+- [ ] Check that the title, description, canonical URL, Open Graph URL, and
+  structured data all describe the same page.
+
+## Pre-deployment checks
+
+Run this PowerShell check from the repository root. The result should be `0`:
+
+```powershell
+$matches = Get-ChildItem -Recurse -Filter *.html |
+  Select-String -Pattern 'href="[^"]*index\.html[^"]*"'
+$matches.Count
+```
+
+Check that every HTML page contains a canonical tag:
+
+```powershell
+Get-ChildItem -Recurse -Filter *.html | ForEach-Object {
+  $html = Get-Content -Raw -LiteralPath $_.FullName
+  if ($html -notmatch 'rel="canonical"') {
+    Write-Output "Missing canonical: $($_.FullName)"
+  }
+}
+```
+
+- [ ] Confirm the `index.html` link check returns `0`.
+- [ ] Confirm the canonical check reports no missing tags.
+- [ ] Inspect `sitemap.xml` for duplicate or non-canonical URLs.
+- [ ] Test homepage, navigation, blog cards, and related-article links.
+- [ ] Run `git diff --check`.
+
+## Search Console follow-up
+
+- [ ] Deploy the changes before starting validation.
+- [ ] Inspect the clean canonical URL in Google Search Console.
+- [ ] Confirm the user-declared canonical matches Google's selected canonical.
+- [ ] Resubmit the existing sitemap when its URLs are already correct.
+- [ ] Click **Validate Fix** after deployment.
+- [ ] Allow time for Google to recrawl the affected URLs.
+
+## Previous finding: explicit `index.html` links
+
+Google Search Console reported these URLs as **Alternate page with proper
+canonical tag**:
+
+- `https://baboostories.com/index.html`
+- `https://baboostories.com/blog/best-bedtime-story-app-for-toddlers/index.html`
+- `https://baboostories.com/blog/toddler-wont-sleep-bedtime-story-routine/index.html`
+- `https://baboostories.com/blog/are-scary-stories-good-for-toddlers/index.html`
+
+The canonical tags and sitemap used clean URLs, but internal links still
+contained `index.html`. That allowed Google to discover duplicate URL versions.
+The internal links were changed to `/` and clean trailing-slash article URLs.
+
+Because this repository is served as a static GitHub Pages site, repository
+files cannot define normal server-side `301` redirects. Preventing discovery of
+the duplicate URLs through internal links, canonical tags, and the sitemap is
+therefore especially important.

--- a/about-developer.html
+++ b/about-developer.html
@@ -40,7 +40,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -59,7 +59,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html" aria-current="page">About the Developer</a>
           <a href="blogs.html">Blog</a>
@@ -289,7 +289,7 @@
         </div>
         <div class="footer-links">
           <strong>Explore</strong>
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a
             href="https://play.google.com/store/apps/details?id=baboo.stories&pcampaignid=web_share"

--- a/app-links.html
+++ b/app-links.html
@@ -59,7 +59,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -78,7 +78,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html" aria-current="page">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html">Blog</a>
@@ -282,7 +282,7 @@
         </div>
         <div class="footer-links">
           <strong>Explore</strong>
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a
             href="https://play.google.com/store/apps/details?id=baboo.stories&pcampaignid=web_share"

--- a/blog-10-minute-toddler-bedtime-routine.html
+++ b/blog-10-minute-toddler-bedtime-routine.html
@@ -120,7 +120,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -144,7 +144,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html" aria-current="page">Blog</a>

--- a/blog-bedtime-rituals.html
+++ b/blog-bedtime-rituals.html
@@ -69,7 +69,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+      <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -88,7 +88,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+        <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html" aria-current="page">Blog</a>

--- a/blog-bedtime-stories-for-3-year-olds.html
+++ b/blog-bedtime-stories-for-3-year-olds.html
@@ -115,7 +115,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -139,7 +139,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html" aria-current="page">Blog</a>

--- a/blog-best-bedtime-stories-toddlers.html
+++ b/blog-best-bedtime-stories-toddlers.html
@@ -103,7 +103,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+      <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -122,7 +122,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+        <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html" aria-current="page">Blog</a>

--- a/blog-how-to-read-kids-stories.html
+++ b/blog-how-to-read-kids-stories.html
@@ -51,10 +51,10 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html"><img class="brand-logo" src="assets/images/Kids-stories.png" alt="Baboo Stories logo" width="48" height="48" /><span class="brand-name">Baboo Stories</span></a>
+    <a class="brand" href="/"><img class="brand-logo" src="assets/images/Kids-stories.png" alt="Baboo Stories logo" width="48" height="48" /><span class="brand-name">Baboo Stories</span></a>
         <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation"><span class="sr-only">Toggle navigation</span><span class="nav-toggle-icon" aria-hidden="true"><span></span><span></span><span></span></span></button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a><a href="app-links.html">Get the App</a><a href="about-developer.html">About the Developer</a><a href="blogs.html" aria-current="page">Blog</a><a href="privacy-policy.html">Privacy Policy</a><a href="early-bird-signup.html">Early Bird Access</a>
+      <a href="/">Home</a><a href="app-links.html">Get the App</a><a href="about-developer.html">About the Developer</a><a href="blogs.html" aria-current="page">Blog</a><a href="privacy-policy.html">Privacy Policy</a><a href="early-bird-signup.html">Early Bird Access</a>
         </div>
       </nav>
     </header>

--- a/blog-reading-toddlers.html
+++ b/blog-reading-toddlers.html
@@ -63,7 +63,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+      <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -82,7 +82,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+        <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html" aria-current="page">Blog</a>

--- a/blog-storytelling-prompts.html
+++ b/blog-storytelling-prompts.html
@@ -69,7 +69,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+      <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -88,7 +88,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+        <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html" aria-current="page">Blog</a>

--- a/blog/5-minute-bedtime-stories-busy-weeknights/index.html
+++ b/blog/5-minute-bedtime-stories-busy-weeknights/index.html
@@ -124,7 +124,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -146,7 +146,7 @@
           ></span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+          <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>
@@ -253,13 +253,13 @@
           <p>
             If your family needs a slightly longer version, you can also read
             our hub for a
-            <a href="../bedtime-routines/index.html"
+            <a href="/blog/bedtime-routines/"
               >consistent bedtime routine for toddlers</a
             >, follow a
             <a href="../../blog-10-minute-toddler-bedtime-routine.html"
               >10-minute toddler bedtime routine</a
             >, or use this guide for when a
-            <a href="../../blog/toddler-wont-sleep-bedtime-story-routine/index.html"
+            <a href="/blog/toddler-wont-sleep-bedtime-story-routine/"
               >toddler won't sleep</a
             >.
           </p>
@@ -313,7 +313,7 @@
             A 5-minute bedtime story does not need a long discussion. One small
             prompt can help your toddler feel seen without waking the room back
             up. You can also
-            <a href="../calming-prompts/index.html"
+            <a href="/blog/calming-prompts/"
               >pair it with calming conversation prompts</a
             >
             when your child needs help naming feelings.
@@ -388,7 +388,7 @@
           </p>
           <p>
             If you want more age-specific choices, browse our guide to
-            <a href="../bedtime-stories-by-age/index.html"
+            <a href="/blog/bedtime-stories-by-age/"
               >bedtime stories for 2-year-olds</a
             >. If you want the stories ready inside your routine, the
             <a href="../../app-links.html">Baboo Stories app</a> keeps parents

--- a/blog/are-scary-stories-good-for-toddlers/index.html
+++ b/blog/are-scary-stories-good-for-toddlers/index.html
@@ -71,7 +71,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+      <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -90,7 +90,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+        <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>

--- a/blog/bedtime-routines/index.html
+++ b/blog/bedtime-routines/index.html
@@ -61,7 +61,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+      <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -83,7 +83,7 @@
           ></span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+        <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>
@@ -166,7 +166,7 @@
           <div class="card-grid">
             <article class="card">
               <h3>
-                <a href="../kids-evening-routine-ages-2-5/index.html"
+                <a href="/blog/kids-evening-routine-ages-2-5/"
                   >Kids evening routine for ages 2–5</a
                 >
               </h3>
@@ -177,7 +177,7 @@
             </article>
             <article class="card">
               <h3>
-                <a href="../toddler-screen-time-before-bed/index.html"
+                <a href="/blog/toddler-screen-time-before-bed/"
                   >Toddler wants screen time before bed?</a
                 >
               </h3>
@@ -188,7 +188,7 @@
             </article>
             <article class="card">
               <h3>
-                <a href="../5-minute-bedtime-stories-busy-weeknights/index.html"
+                <a href="/blog/5-minute-bedtime-stories-busy-weeknights/"
                   >5-minute bedtime stories for busy weeknights</a
                 >
               </h3>
@@ -210,7 +210,7 @@
             </article>
             <article class="card">
               <h3>
-                <a href="../toddler-wont-sleep-bedtime-story-routine/index.html"
+                <a href="/blog/toddler-wont-sleep-bedtime-story-routine/"
                   >Toddler won't sleep? Try a simple story routine</a
                 >
               </h3>
@@ -223,9 +223,9 @@
 
           <p>
             For story choices, browse our
-            <a href="../bedtime-stories-by-age/index.html">bedtime stories by age</a>.
+            <a href="/blog/bedtime-stories-by-age/">bedtime stories by age</a>.
             For emotional check-ins, pair your routine with
-            <a href="../calming-prompts/index.html">calming bedtime prompts</a>. You can
+            <a href="/blog/calming-prompts/">calming bedtime prompts</a>. You can
             also use the <a href="../../app-links.html">Baboo Stories app</a>
             when you want a short read-aloud story ready to go.
           </p>

--- a/blog/bedtime-stories-by-age/index.html
+++ b/blog/bedtime-stories-by-age/index.html
@@ -67,7 +67,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -89,7 +89,7 @@
           ></span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+          <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>
@@ -179,7 +179,7 @@
             </article>
             <article class="card">
               <h3>
-                <a href="../5-minute-bedtime-stories-busy-weeknights/index.html"
+                <a href="/blog/5-minute-bedtime-stories-busy-weeknights/"
                   >5-minute bedtime stories</a
                 >
               </h3>
@@ -192,10 +192,10 @@
 
           <p>
             After you choose a story, use a
-            <a href="../bedtime-routines/index.html">consistent bedtime routine</a> to
+            <a href="/blog/bedtime-routines/">consistent bedtime routine</a> to
             help your child know what happens next. For values-based
             conversations, try our
-            <a href="../calming-prompts/index.html">calming prompts for toddlers</a>.
+            <a href="/blog/calming-prompts/">calming prompts for toddlers</a>.
           </p>
         </div>
       </article>

--- a/blog/best-bedtime-story-app-for-toddlers/index.html
+++ b/blog/best-bedtime-story-app-for-toddlers/index.html
@@ -130,7 +130,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -152,7 +152,7 @@
           ></span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+          <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>
@@ -357,7 +357,7 @@
             tablet themselves, and keep the bedtime interaction centered on the
             relationship. The app supports the ritual, but it does not take over
             the ritual. If your toddler is asking for videos at night, this
-            <a href="../toddler-screen-time-before-bed/index.html">calmer screen-light bedtime routine</a>
+            <a href="/blog/toddler-screen-time-before-bed/">calmer screen-light bedtime routine</a>
             can help you replace autoplay with one parent-led story.
           </p>
 

--- a/blog/calming-prompts/index.html
+++ b/blog/calming-prompts/index.html
@@ -61,7 +61,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+      <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -83,7 +83,7 @@
           ></span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+        <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>
@@ -163,7 +163,7 @@
             </article>
             <article class="card">
               <h3>
-                <a href="../5-minute-bedtime-stories-busy-weeknights/index.html"
+                <a href="/blog/5-minute-bedtime-stories-busy-weeknights/"
                   >Pair prompts with 5-minute stories</a
                 >
               </h3>
@@ -187,9 +187,9 @@
 
           <p>
             If your child needs more structure, begin with a
-            <a href="../bedtime-routines/index.html">bedtime routine for toddlers</a>.
+            <a href="/blog/bedtime-routines/">bedtime routine for toddlers</a>.
             If you need a story to pair with these questions, browse our
-            <a href="../bedtime-stories-by-age/index.html">stories for 2-year-olds</a> or
+            <a href="/blog/bedtime-stories-by-age/">stories for 2-year-olds</a> or
             open the <a href="../../app-links.html">Baboo Stories app</a>.
           </p>
         </div>

--- a/blog/kids-evening-routine-ages-2-5/index.html
+++ b/blog/kids-evening-routine-ages-2-5/index.html
@@ -67,7 +67,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -89,7 +89,7 @@
           ></span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+          <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>
@@ -273,11 +273,11 @@
           </p>
           <p>
             Not sure what fits tonight? Browse
-            <a href="../bedtime-stories-by-age/index.html"
+            <a href="/blog/bedtime-stories-by-age/"
               >bedtime stories by age</a
             >
             or use these
-            <a href="../calming-prompts/index.html">calming bedtime prompts</a>.
+            <a href="/blog/calming-prompts/">calming bedtime prompts</a>.
           </p>
 
           <h3>7:55 PM – Lights down and final goodnight</h3>
@@ -300,7 +300,7 @@
             Keep your response warm and consistent: “I know you want another
             story. Tonight we finished one story. Tomorrow we can read again.”
             Consistency matters more than perfection. For tougher nights, try
-            this <a href="../toddler-wont-sleep-bedtime-story-routine/index.html"
+            this <a href="/blog/toddler-wont-sleep-bedtime-story-routine/"
               >simple story routine for bedtime resistance</a
             >.
           </p>
@@ -362,7 +362,7 @@
           </ul>
           <p>
             Read more about
-            <a href="../toddler-screen-time-before-bed/index.html"
+            <a href="/blog/toddler-screen-time-before-bed/"
               >replacing bedtime screen time with a calmer story routine</a
             >.
           </p>

--- a/blog/parent-led-storytelling-vs-auto-play-story-apps/index.html
+++ b/blog/parent-led-storytelling-vs-auto-play-story-apps/index.html
@@ -79,10 +79,10 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html"><img class="brand-logo" src="../../assets/images/Kids-stories.png" alt="Baboo Stories logo" width="48" height="48" /><span class="brand-name">Baboo Stories</span></a>
+    <a class="brand" href="/"><img class="brand-logo" src="../../assets/images/Kids-stories.png" alt="Baboo Stories logo" width="48" height="48" /><span class="brand-name">Baboo Stories</span></a>
         <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="primary-navigation"><span class="sr-only">Toggle navigation</span><span class="nav-toggle-icon" aria-hidden="true"><span></span><span></span><span></span></span></button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a><a href="../../app-links.html">Get the App</a><a href="../../about-developer.html">About the Developer</a><a href="../../blogs.html" aria-current="page">Blog</a><a href="../../privacy-policy.html">Privacy Policy</a><a href="../../early-bird-signup.html">Early Bird Access</a>
+      <a href="/">Home</a><a href="../../app-links.html">Get the App</a><a href="../../about-developer.html">About the Developer</a><a href="../../blogs.html" aria-current="page">Blog</a><a href="../../privacy-policy.html">Privacy Policy</a><a href="../../early-bird-signup.html">Early Bird Access</a>
         </div>
       </nav>
     </header>

--- a/blog/stages-of-helping-your-child-adapt-to-story-time/index.html
+++ b/blog/stages-of-helping-your-child-adapt-to-story-time/index.html
@@ -87,7 +87,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -109,7 +109,7 @@
           ></span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+          <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>
@@ -370,7 +370,7 @@
 
           <h2>How Baboo Stories can help</h2>
           <p>
-            <a href="../../index.html">Baboo Stories</a> helps parents find
+            <a href="/">Baboo Stories</a> helps parents find
             short, gentle, calming stories for parent-led reading. It is designed
             to support bonding, imagination, and a calmer bedtime routine, not
             overstimulating child-alone screen time.

--- a/blog/toddler-screen-time-before-bed/index.html
+++ b/blog/toddler-screen-time-before-bed/index.html
@@ -130,7 +130,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -152,7 +152,7 @@
           ></span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+          <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>
@@ -284,7 +284,7 @@
             rule that feels impossible.
           </p>
           <p>
-            If you already use a <a href="../bedtime-routines/index.html">simple toddler bedtime routine</a>,
+          If you already use a <a href="/blog/bedtime-routines/">simple toddler bedtime routine</a>,
             this can fit inside it. The story does not need to be long. It only
             needs to signal that the busy part of the day is ending.
           </p>
@@ -303,7 +303,7 @@
           </p>
           <p>
             Baboo Stories is designed for this screen-light approach. It is a
-            <a href="../best-bedtime-story-app-for-toddlers/index.html">bedtime story app for toddlers</a>
+            <a href="/blog/best-bedtime-story-app-for-toddlers/">bedtime story app for toddlers</a>
             that supports parent-led reading, not child-led scrolling. The focus
             stays on your voice, your closeness, and the story you share
             together.
@@ -320,11 +320,11 @@
             <li><strong>Put the device in the parent's hand.</strong> Say clearly that you will choose and read.</li>
             <li><strong>Choose one gentle story.</strong> Keep the choice small so bedtime does not become a menu.</li>
             <li><strong>Read aloud slowly.</strong> Let your voice become softer as the story goes on.</li>
-            <li><strong>Ask one soft question.</strong> Try something simple from these <a href="../calming-prompts/index.html">calming bedtime prompts</a>.</li>
+          <li><strong>Ask one soft question.</strong> Try something simple from these <a href="/blog/calming-prompts/">calming bedtime prompts</a>.</li>
             <li><strong>Repeat the same goodnight phrase.</strong> For example, “Story is done, cuddle is done, now we rest.”</li>
           </ol>
           <p>
-            On busy nights, choose a shorter version. A <a href="../5-minute-bedtime-stories-busy-weeknights/index.html">5-minute bedtime story</a>
+          On busy nights, choose a shorter version. A <a href="/blog/5-minute-bedtime-stories-busy-weeknights/">5-minute bedtime story</a>
             can be enough when the rhythm is consistent.
           </p>
 

--- a/blog/toddler-wont-sleep-bedtime-story-routine/index.html
+++ b/blog/toddler-wont-sleep-bedtime-story-routine/index.html
@@ -109,7 +109,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="../../index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="../../assets/images/Kids-stories.png"
@@ -131,7 +131,7 @@
           ></span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="../../index.html">Home</a>
+          <a href="/">Home</a>
           <a href="../../app-links.html">Get the App</a>
           <a href="../../about-developer.html">About the Developer</a>
           <a href="../../blogs.html" aria-current="page">Blog</a>

--- a/blogs.html
+++ b/blogs.html
@@ -52,7 +52,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+      <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -76,7 +76,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+        <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html" aria-current="page">Blog</a>
@@ -160,7 +160,7 @@
         <div class="card-grid">
           <article class="card">
             <h3>
-              <a href="blog/kids-evening-routine-ages-2-5/index.html"
+              <a href="/blog/kids-evening-routine-ages-2-5/"
                 >Kids Evening Routine for Ages 2–5: A Calm Wind-Down Plan</a
               >
             </h3>
@@ -170,13 +170,13 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/kids-evening-routine-ages-2-5/index.html"
+                href="/blog/kids-evening-routine-ages-2-5/"
               >Read the evening plan</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/toddler-screen-time-before-bed/index.html"
+              <a href="/blog/toddler-screen-time-before-bed/"
                 >Toddler Wants Screen Time Before Bed? Try This Calmer Story
                 Routine Instead</a
               >
@@ -187,13 +187,13 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/toddler-screen-time-before-bed/index.html"
+                href="/blog/toddler-screen-time-before-bed/"
               >Read the routine</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/parent-led-storytelling-vs-auto-play-story-apps/index.html"
+              <a href="/blog/parent-led-storytelling-vs-auto-play-story-apps/"
                 >Parent-Led Storytelling vs Auto-Play Story Apps: Which Is
                 Better at Bedtime?</a
               >
@@ -205,13 +205,13 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/parent-led-storytelling-vs-auto-play-story-apps/index.html"
+                href="/blog/parent-led-storytelling-vs-auto-play-story-apps/"
               >Read the comparison</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/bedtime-routines/index.html"
+              <a href="/blog/bedtime-routines/"
                 >Bedtime Routine for Toddlers: 5 Calm Steps That Work</a
               >
             </h3>
@@ -219,13 +219,13 @@
               Start with the routines hub for toddler bedtime steps, quick story
               routines, and parent-led wind-down ideas.
             </p>
-            <a class="btn btn-secondary" href="blog/bedtime-routines/index.html"
+              <a class="btn btn-secondary" href="/blog/bedtime-routines/"
               >Open the hub</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/bedtime-stories-by-age/index.html"
+              <a href="/blog/bedtime-stories-by-age/"
                 >Best Bedtime Stories for 2-Year-Olds: Gentle Tales by Age</a
               >
             </h3>
@@ -235,13 +235,13 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/bedtime-stories-by-age/index.html"
+                href="/blog/bedtime-stories-by-age/"
               >Browse stories</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/calming-prompts/index.html"
+              <a href="/blog/calming-prompts/"
                 >Bedtime Anxiety in Toddlers: 7 Calming Conversation Prompts</a
               >
             </h3>
@@ -249,13 +249,13 @@
               Use gentle bedtime prompts after stories to help toddlers name
               feelings, feel connected, and settle.
             </p>
-            <a class="btn btn-secondary" href="blog/calming-prompts/index.html"
+              <a class="btn btn-secondary" href="/blog/calming-prompts/"
               >Read the prompts</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/5-minute-bedtime-stories-busy-weeknights/index.html"
+              <a href="/blog/5-minute-bedtime-stories-busy-weeknights/"
                 >5-Minute Bedtime Stories for Busy Weeknights: Calm Routines
                 Parents Actually Use</a
               >
@@ -266,14 +266,14 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/5-minute-bedtime-stories-busy-weeknights/index.html"
+                href="/blog/5-minute-bedtime-stories-busy-weeknights/"
               >Read the routine</a
             >
           </article>
           <article class="card">
             <h3>
               <a
-                href="blog/stages-of-helping-your-child-adapt-to-story-time/index.html"
+                href="/blog/stages-of-helping-your-child-adapt-to-story-time/"
                 >How to Help Your Child Get Used to Story Time: 6 Gentle Stages
                 for Parents</a
               >
@@ -285,13 +285,13 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/stages-of-helping-your-child-adapt-to-story-time/index.html"
+                href="/blog/stages-of-helping-your-child-adapt-to-story-time/"
               >Read the stages</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/best-bedtime-story-app-for-toddlers/index.html"
+              <a href="/blog/best-bedtime-story-app-for-toddlers/"
                 >Best Bedtime Story App for Toddlers: What Parents Should Look
                 For</a
               >
@@ -303,13 +303,13 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/best-bedtime-story-app-for-toddlers/index.html"
+                href="/blog/best-bedtime-story-app-for-toddlers/"
               >Read the buying guide</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/are-scary-stories-good-for-toddlers/index.html"
+              <a href="/blog/are-scary-stories-good-for-toddlers/"
                 >Are Scary Stories Healthy for Toddlers? Why Gentle Bedtime
                 Stories Matter</a
               >
@@ -320,7 +320,7 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/are-scary-stories-good-for-toddlers/index.html"
+                href="/blog/are-scary-stories-good-for-toddlers/"
               >Read the guide</a
             >
           </article>
@@ -344,7 +344,7 @@
           </article>
           <article class="card">
             <h3>
-              <a href="blog/toddler-wont-sleep-bedtime-story-routine/index.html"
+              <a href="/blog/toddler-wont-sleep-bedtime-story-routine/"
                 >Toddler Won’t Sleep? Try a Simple Bedtime Story Routine</a
               >
             </h3>
@@ -355,7 +355,7 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/toddler-wont-sleep-bedtime-story-routine/index.html"
+                href="/blog/toddler-wont-sleep-bedtime-story-routine/"
               >Read the routine</a
             >
           </article>

--- a/early-bird-signup.html
+++ b/early-bird-signup.html
@@ -41,7 +41,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -60,7 +60,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html">Blog</a>
@@ -182,7 +182,7 @@
         </div>
         <div class="footer-links">
           <strong>Explore</strong>
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a
             href="https://play.google.com/store/apps/details?id=baboo.stories&pcampaignid=web_share"

--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -130,7 +130,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html">Blog</a>
@@ -290,9 +290,9 @@
         </p>
         <div class="keyword-list" aria-label="Popular Baboo Stories use cases">
           <a href="blog-reading-toddlers.html">How to read stories to toddlers</a>
-          <a href="blog/bedtime-routines/index.html">Bedtime routine for toddlers</a>
-          <a href="blog/calming-prompts/index.html">Calming prompts for kids</a>
-          <a href="blog/bedtime-stories-by-age/index.html">Stories for 2-year-olds</a>
+              <a href="/blog/bedtime-routines/">Bedtime routine for toddlers</a>
+              <a href="/blog/calming-prompts/">Calming prompts for kids</a>
+              <a href="/blog/bedtime-stories-by-age/">Stories for 2-year-olds</a>
           <a href="app-links.html">Android bedtime story app</a>
           <a href="early-bird-signup.html">Parent beta list</a>
         </div>
@@ -307,7 +307,7 @@
         <div class="card-grid">
           <article class="card">
             <h3>
-              <a href="blog/5-minute-bedtime-stories-busy-weeknights/index.html"
+              <a href="/blog/5-minute-bedtime-stories-busy-weeknights/"
                 >5-minute bedtime stories for busy weeknights</a
               >
             </h3>
@@ -317,13 +317,13 @@
             </p>
             <a
               class="btn btn-secondary"
-              href="blog/5-minute-bedtime-stories-busy-weeknights/index.html"
+                href="/blog/5-minute-bedtime-stories-busy-weeknights/"
               >Read the routine</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/calming-prompts/index.html"
+              <a href="/blog/calming-prompts/"
                 >Bedtime anxiety prompts for toddlers</a
               >
             </h3>
@@ -331,13 +331,13 @@
               Try gentle conversation prompts that help children name feelings
               and settle after a bedtime story.
             </p>
-            <a class="btn btn-secondary" href="blog/calming-prompts/index.html"
+              <a class="btn btn-secondary" href="/blog/calming-prompts/"
               >Explore the prompts</a
             >
           </article>
           <article class="card">
             <h3>
-              <a href="blog/bedtime-stories-by-age/index.html"
+              <a href="/blog/bedtime-stories-by-age/"
                 >Best bedtime stories for 2-year-olds</a
               >
             </h3>
@@ -345,7 +345,7 @@
               Browse gentle, age-appropriate story ideas for toddlers and
               preschoolers before lights out.
             </p>
-            <a class="btn btn-secondary" href="blog/bedtime-stories-by-age/index.html"
+              <a class="btn btn-secondary" href="/blog/bedtime-stories-by-age/"
               >Browse by age</a
             >
           </article>
@@ -396,7 +396,7 @@
               Yes. Baboo Stories is designed for families with toddlers and
               young children, with gentle stories, short sessions, and parent-led
               prompts that make bedtime easier. See our guide to
-              <a href="blog/bedtime-stories-by-age/index.html"
+              <a href="/blog/bedtime-stories-by-age/"
                 >bedtime stories for 2-year-olds</a
               >
               for age-appropriate story ideas.
@@ -408,7 +408,7 @@
               No. Baboo Stories supports parent-child connection by giving
               parents ready-to-use stories and questions they can read, discuss,
               and personalize together. For a deeper comparison, read about the
-              <a href="blog/best-bedtime-story-app-for-toddlers/index.html"
+              <a href="/blog/best-bedtime-story-app-for-toddlers/"
                 >best bedtime story app for toddlers</a
               >.
             </p>
@@ -446,7 +446,7 @@
         </div>
         <div class="footer-links">
           <strong>Explore</strong>
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="blogs.html">Blog</a>
           <a href="app-links.html">Get the App</a>
           <a
@@ -459,9 +459,9 @@
         </div>
         <div class="footer-links">
           <strong>Popular guides</strong>
-          <a href="blog/bedtime-routines/index.html">Bedtime routine for toddlers</a>
-          <a href="blog/bedtime-stories-by-age/index.html">Stories for 2-year-olds</a>
-          <a href="blog/calming-prompts/index.html">Calming bedtime prompts</a>
+          <a href="/blog/bedtime-routines/">Bedtime routine for toddlers</a>
+          <a href="/blog/bedtime-stories-by-age/">Stories for 2-year-olds</a>
+          <a href="/blog/calming-prompts/">Calming bedtime prompts</a>
         </div>
         <div class="footer-links">
           <strong>Company</strong>

--- a/privacy-policy.html
+++ b/privacy-policy.html
@@ -40,7 +40,7 @@
   <body>
     <header>
       <nav class="navbar" aria-label="Primary">
-        <a class="brand" href="index.html">
+        <a class="brand" href="/">
           <img
             class="brand-logo"
             src="assets/images/Kids-stories.png"
@@ -59,7 +59,7 @@
           </span>
         </button>
         <div class="nav-links" id="primary-navigation" data-visible="false">
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a href="about-developer.html">About the Developer</a>
           <a href="blogs.html">Blog</a>
@@ -201,7 +201,7 @@
         </div>
         <div class="footer-links">
           <strong>Explore</strong>
-          <a href="index.html">Home</a>
+          <a href="/">Home</a>
           <a href="app-links.html">Get the App</a>
           <a
             href="https://play.google.com/store/apps/details?id=baboo.stories&pcampaignid=web_share"


### PR DESCRIPTION
## What changed

- Replaced internal `index.html` links with clean canonical URLs across the site.
- Updated homepage, blog listing, navigation, and related-article links.
- Added `TECHNICAL_CHECKLIST.md` with URL, canonical, sitemap, deployment, and Search Console checks.

## Why

Google Search Console reported `/index.html` variants as alternate pages. Canonical tags and the sitemap already used clean URLs, but internal links were still allowing Google to discover duplicate URL forms.

## Impact

Internal discovery now consistently points to `/` and trailing-slash article URLs. Existing page content and canonical destinations are unchanged.

## Validation

- Confirmed zero internal `href` values contain `index.html`.
- Confirmed every HTML page contains a canonical tag.
- `git diff --check` passes.